### PR TITLE
Add pointer about GitHub's builtin ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- prettier-ignore -->
+↖️ Click <img height="16" valign="middle" src="https://i.imgur.com/yFtQXvN.png" /> for TOC
+
 # Awesome Dev Containers [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 <div id="top"></div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61068799/217404413-81f2d7c2-d9b1-4d88-8371-6e86f2b4f290.png)

https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/