### PR TITLE
Add aicontainer to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Pieces](https://pieces.app/) — An on-device copilot that helps you capture, enrich, and reuse code, streamline collaboration, and solve complex problems through a contextual understanding of your workflow.
 - [crib](https://fgrehm.github.io/crib) - A lean devcontainer runner that shells out to Docker/Podman. Single binary, no SSH, just `docker exec`, with experimental support for plugins.
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
+- [aicontainer](https://github.com/stefanoginella/aicontainer) - A CLI that drops a sandboxed dev container into any project for running AI coding agents (Claude Code, Codex) in auto-approve mode, with filesystem isolation, a filtered Docker socket, and an opt-in outbound firewall.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 


### PR DESCRIPTION
Adds **aicontainer** to the **Tools** section.

[aicontainer](https://github.com/stefanoginella/aicontainer) is an MIT-licensed CLI (`npm i -g aicontainer`) that drops a ready-to-use, sandboxed dev container into any project — built on the [Dev Container spec](https://containers.dev/) and `@devcontainers/cli` — for safely running AI coding agents (Claude Code, Codex) in their auto-approve modes. It provides filesystem isolation (only the project dir is writable), a filtered Docker socket via Tecnativa's docker-socket-proxy, a PreToolUse hook, and an opt-in iptables outbound allowlist. Works from the CLI or via VS Code "Reopen in Container."

- Repo: https://github.com/stefanoginella/aicontainer
- npm: https://www.npmjs.com/package/aicontainer

**Disclosure:** I'm the author of aicontainer.

Checklist:
- [x] One-line entry in GitHub Flavored Markdown, matching the existing Tools format
- [x] Added to the end of the Tools list
- [x] Project is relevant to dev containers, MIT-licensed, documented, and actively maintained
